### PR TITLE
Auto-create patch files during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ROMs
 *.z64
 *.log
+*.xdelta
 
 # Tools
 tools/*

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,16 @@ PROGRAM_NAME=19XX
 
 all:
 	# assemble rom
-	tools/_bass -o $(PROGRAM_NAME)CE.z64 $(PROGRAM_NAME)CE.asm -sym bass.log
-	tools/_bass -o $(PROGRAM_NAME)TE.z64 $(PROGRAM_NAME)TE.asm -sym bass.log
+	tools/_bass -o roms/$(PROGRAM_NAME)CE.z64 $(PROGRAM_NAME)CE.asm -sym bass.log
+	tools/_bass -o roms/$(PROGRAM_NAME)TE.z64 $(PROGRAM_NAME)TE.asm -sym bass.log
 
 	# update checksum
-	tools/n64crc $(PROGRAM_NAME)CE.z64
-	tools/n64crc $(PROGRAM_NAME)TE.z64
+	tools/n64crc roms/$(PROGRAM_NAME)CE.z64
+	tools/n64crc roms/$(PROGRAM_NAME)TE.z64
+
+	# create patch files
+	xdelta3 -e -f -s roms/original.z64 roms/$(PROGRAM_NAME)CE.z64 patches/$(PROGRAM_NAME)CE.xdelta
+	xdelta3 -e -f -s roms/original.z64 roms/$(PROGRAM_NAME)TE.z64 patches/$(PROGRAM_NAME)TE.xdelta
 
 	# show time stamp
 	date
@@ -35,7 +39,10 @@ debug:
 
 clean:
 	# remove roms
-	rm -rf $(PROGRAM_NAME)*.z64
+	rm -rf roms/$(PROGRAM_NAME)*.z64
+
+	# remove patches
+	rm -rf patches/$(PROGRAM_NAME)*.xdelta
 
 	# remove log files
 	rm -rf *.log

--- a/patches/README.txt
+++ b/patches/README.txt
@@ -1,0 +1,1 @@
+Legal patch files are created here. Legally aquire your own ROMs.


### PR DESCRIPTION
- Creates xdelta style patch files during build
This requires xdelta3 on the machine (apt-get install xdelta3)
- Moves ROMs to roms directory
- Clean patch files during clean